### PR TITLE
deactivate request validation for catsAndDogs

### DIFF
--- a/.insomnia/ApiSpec/spc_d95de7ad75f04714a033d9e6544caea4.yml
+++ b/.insomnia/ApiSpec/spc_d95de7ad75f04714a033d9e6544caea4.yml
@@ -75,7 +75,7 @@ contents: >
           - CatOrDog
           - Body
         x-kong-plugin-request-validator:
-          enabled: true 
+          enabled: false 
     /delay/{delay}: 
       get:
         parameters:


### PR DESCRIPTION
inso generate is actually not copying the component definitions, but the references which could not be handled by kong gateway